### PR TITLE
Run migrations in dedicated Docker Compose service

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ ayre_fren_ba/
 ├── requirements.txt
 └── README.md
 ```
+
+## Ejecutar con Docker
+
+Para levantar la aplicación y aplicar las migraciones automáticamente:
+
+```bash
+docker compose up --build
+```
+
+El servicio `migrate` ejecuta `alembic upgrade head` y, una vez finalizado,
+inicia el servicio `web`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,18 @@ services:
     networks:
       - app-network
 
+  migrate:
+    build: .
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql+asyncpg://ayre_user:ayre_password@db:5432/ayre_fren_db
+    depends_on:
+      - db
+    command: alembic upgrade head
+    restart: "no"
+    networks:
+      - app-network
+
   web:
     build: .
     env_file: .env
@@ -23,7 +35,8 @@ services:
       - "8000:8000"
     depends_on:
       - db
-    command: bash -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"
+      - migrate
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
     networks:
       - app-network
 


### PR DESCRIPTION
## Summary
- handle Alembic migrations in a new `migrate` service
- start the FastAPI server without running migrations each time
- document how to launch the app with Docker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68660ab3950c83229cddbbc6940adfea