### PR TITLE
Add truck search endpoint

### DIFF
--- a/app/db/repositories/trucks.py
+++ b/app/db/repositories/trucks.py
@@ -13,6 +13,12 @@ class TrucksRepository:
         result = await self.db.execute(select(Truck).where(Truck.id == truck_id))
         return result.scalars().first()
 
+    async def get_by_plate(self, license_plate: str) -> Truck | None:
+        result = await self.db.execute(
+            select(Truck).where(Truck.license_plate == license_plate)
+        )
+        return result.scalar_one_or_none()
+
     async def create(self, truck_data: TruckCreate) -> Truck:
         truck = Truck(**truck_data.model_dump())
         self.db.add(truck)

--- a/app/routers/trucks.py
+++ b/app/routers/trucks.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.constants.roles import ADMIN, REVISOR
 from app.core.database import get_db
 from app.core.dependencies import roles_allowed
-from app.schemas.trucks import TruckCreate, TruckInDB, TruckUpdate
+from app.schemas.trucks import TruckCreate, TruckInDB, TruckUpdate, TruckWithClient
 from app.services.trucks import TrucksService
 
 trucks_router = APIRouter()
@@ -30,6 +30,16 @@ async def get_truck(
 ):
     service = TrucksService(db)
     return await service.get_truck(truck_id)
+
+
+@trucks_router.get("/plate/{license_plate}", response_model=TruckWithClient)
+async def get_truck_by_plate(
+    license_plate: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: str = Depends(roles_allowed(ADMIN, REVISOR)),
+):
+    service = TrucksService(db)
+    return await service.get_by_plate(license_plate)
 
 
 @trucks_router.post("/", response_model=TruckInDB)

--- a/app/schemas/trucks.py
+++ b/app/schemas/trucks.py
@@ -1,6 +1,8 @@
 # app/schemas/truck.py
 from pydantic import BaseModel, conint, constr
 
+from app.schemas.clients import ClientOut
+
 
 class TruckBase(BaseModel):
     client_id: int
@@ -27,3 +29,8 @@ class TruckInDB(TruckBase):
 
     class Config:
         from_attributes = True
+
+
+class TruckWithClient(BaseModel):
+    truck: TruckInDB
+    client: ClientOut

--- a/app/services/trucks.py
+++ b/app/services/trucks.py
@@ -2,6 +2,7 @@ from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.repositories.trucks import TrucksRepository
+from app.db.repositories.clients import ClientsRepository
 from app.models.trucks import Truck
 from app.schemas.trucks import TruckCreate, TruckUpdate
 
@@ -9,6 +10,7 @@ from app.schemas.trucks import TruckCreate, TruckUpdate
 class TrucksService:
     def __init__(self, db: AsyncSession):
         self.repo = TrucksRepository(db)
+        self.clients_repo = ClientsRepository(db)
 
     async def get_truck(self, truck_id: int) -> Truck:
         truck = await self.repo.get_by_id(truck_id)
@@ -17,6 +19,15 @@ class TrucksService:
                 status_code=status.HTTP_404_NOT_FOUND, detail="Truck not found"
             )
         return truck
+
+    async def get_by_plate(self, license_plate: str):
+        truck = await self.repo.get_by_plate(license_plate)
+        if not truck:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Truck not found"
+            )
+        client = await self.clients_repo.get_by_id(truck.client_id)
+        return {"truck": truck, "client": client}
 
     async def create_truck(self, truck_create: TruckCreate) -> Truck:
         return await self.repo.create(truck_create)


### PR DESCRIPTION
## Summary
- extend truck schemas to include a client
- add repository method to search trucks by license plate
- add service method returning truck and client
- expose new `/trucks/plate/{license_plate}` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68671e34249c83229af88999746fb090