### PR TITLE
Fix docker tests

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+# If the first argument is "pytest" we execute the tests directly and skip the
+# usual startup steps for the API server. This allows commands such as:
+#
+#   docker compose -f docker-compose.dev.yml run --rm web pytest
+#
+# to work without uvicorn complaining about unknown options like "--cov".
+if [ "$1" = "pytest" ]; then
+    shift
+    exec pytest "$@"
+fi
+
 python -m scripts.wait_for_db
 alembic upgrade head
 python -m scripts.init_db


### PR DESCRIPTION
## Summary
- allow running tests via docker compose

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6879dc5d1d448329a9b46b4bd778de37