### PR TITLE
Fix missing pytest-cov

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,4 +48,5 @@ watchfiles==1.1.0
 websockets==15.0.1
 pytest==8.2.2
 pytest-asyncio==0.23.7
+pytest-cov==5.0.0
 httpx==0.27.0


### PR DESCRIPTION
## Summary
- add pytest-cov to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6879dd41638c83298b2d1aaac922c212