### PR TITLE
Add bank check exchange flow

### DIFF
--- a/app/models/invoices.py
+++ b/app/models/invoices.py
@@ -84,6 +84,8 @@ class BankCheck(Base):
     check_number = Column(String(50), nullable=False)
     amount = Column(Numeric(10, 2), nullable=False)
     issued_at = Column(DateTime, default=datetime.utcnow)
+    due_date = Column(DateTime, nullable=True)
+    exchange_date = Column(DateTime, nullable=True)
     type = Column(SqlEnum(BankCheckType), nullable=False)
     payment_id = Column(Integer, ForeignKey("payments.id"), nullable=False)
     payment = relationship("Payment", back_populates="bank_checks")

--- a/app/routers/invoices.py
+++ b/app/routers/invoices.py
@@ -7,6 +7,8 @@ from app.constants.roles import ADMIN, REVISOR
 from app.core.database import get_db
 from app.core.dependencies import roles_allowed
 from app.schemas.invoices import (
+    BankCheckExchange,
+    BankCheckOut,
     InvoiceCreate,
     InvoiceDetailOut,
     InvoiceOut,
@@ -14,7 +16,11 @@ from app.schemas.invoices import (
     PaymentMethodOut,
     PaymentOut,
 )
-from app.services.invoices import InvoicesService, PaymentsService
+from app.services.invoices import (
+    BankChecksService,
+    InvoicesService,
+    PaymentsService,
+)
 
 invoice_router = APIRouter()
 
@@ -55,6 +61,17 @@ async def register_payment(
 ):
     service = PaymentsService(db)
     return await service.create(payment_in)
+
+
+@invoice_router.post("/bank-checks/{check_id}/exchange", response_model=BankCheckOut)
+async def exchange_bank_check(
+    check_id: int,
+    exchange_in: BankCheckExchange,
+    db: AsyncSession = Depends(get_db),
+    current_user: str = Depends(roles_allowed(ADMIN, REVISOR)),
+):
+    service = BankChecksService(db)
+    return await service.mark_as_exchanged(check_id, exchange_in)
 
 
 @invoice_router.get("/payments/{invoice_id}/total")

--- a/app/schemas/invoices.py
+++ b/app/schemas/invoices.py
@@ -50,11 +50,13 @@ class BankCheckIn(BaseModel):
     check_number: str
     amount: float
     type: BankCheckType
+    due_date: Optional[datetime] = None
 
 
 class BankCheckOut(BankCheckIn):
     id: int
     issued_at: datetime
+    exchange_date: Optional[datetime] = None
 
     class Config:
         from_attributes = True
@@ -66,6 +68,10 @@ class PaymentMethodOut(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class BankCheckExchange(BaseModel):
+    exchange_date: datetime
 
 
 class InvoiceDetailOut(InvoiceOut):

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -1,0 +1,27 @@
+import logging
+from typing import Iterable
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.constants.roles import ADMIN
+from app.db.repositories.users import UsersRepository
+from app.models.invoices import BankCheck
+
+
+class NotificationService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.users_repo = UsersRepository(db)
+
+    async def _send_email(self, recipients: Iterable[str], subject: str, body: str) -> None:
+        logging.info("Sending email to %s: %s - %s", ", ".join(recipients), subject, body)
+
+    async def notify_due_check(self, check: BankCheck) -> None:
+        admins = await self.users_repo.list(role_id=ADMIN)
+        recipients = [a.email for a in admins]
+        invoice = check.payment.invoice if check.payment else None
+        if invoice and invoice.work_order and invoice.work_order.reviewer:
+            recipients.append(invoice.work_order.reviewer.email)
+        subject = "Cheque próximo a vencer"
+        body = f"El cheque {check.check_number} vence el {check.due_date}"
+        await self._send_email(recipients, subject, body)


### PR DESCRIPTION
## Summary
- add due and exchange dates to `BankCheck`
- new notification service for impending check expirations
- support marking bank checks as exchanged
- expose endpoint to exchange checks
- test the exchange endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687abc3365d083299dff73282d4ba6e0