### PR TITLE
Add expenses models and endpoints

### DIFF
--- a/alembic/versions/b862a5be2d18_add_expenses.py
+++ b/alembic/versions/b862a5be2d18_add_expenses.py
@@ -1,0 +1,62 @@
+"""add expenses tables
+
+Revision ID: b862a5be2d18
+Revises: a7ddd162d893
+Create Date: 2025-07-20 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'b862a5be2d18'
+down_revision: Union[str, Sequence[str], None] = 'a7ddd162d893'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'expense_types',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(length=100), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('name'),
+    )
+    op.create_table(
+        'expenses',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('date', sa.Date(), nullable=False),
+        sa.Column('amount', sa.Numeric(10, 2), nullable=False),
+        sa.Column('description', sa.String(length=255), nullable=True),
+        sa.Column('expense_type_id', sa.Integer(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['expense_type_id'], ['expense_types.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    expense_types = [
+        'Sueldos',
+        'Alquiler',
+        'Luz',
+        'Gas',
+        'Agua',
+        'Internet',
+        'Impuestos',
+        'Mantenimiento',
+    ]
+    op.bulk_insert(
+        sa.table(
+            'expense_types',
+            sa.column('name', sa.String),
+        ),
+        [{'name': n} for n in expense_types],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('expenses')
+    op.drop_table('expense_types')

--- a/alembic/versions/b862a5be2d18_add_expenses.py
+++ b/alembic/versions/b862a5be2d18_add_expenses.py
@@ -5,14 +5,15 @@ Revises: a7ddd162d893
 Create Date: 2025-07-20 00:00:00.000000
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision: str = 'b862a5be2d18'
-down_revision: Union[str, Sequence[str], None] = 'a7ddd162d893'
+revision: str = "b862a5be2d18"
+down_revision: Union[str, Sequence[str], None] = "a7ddd162d893"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -20,43 +21,50 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     """Upgrade schema."""
     op.create_table(
-        'expense_types',
-        sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('name', sa.String(length=100), nullable=False),
-        sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('name'),
+        "expense_types",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
     )
     op.create_table(
-        'expenses',
-        sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('date', sa.Date(), nullable=False),
-        sa.Column('amount', sa.Numeric(10, 2), nullable=False),
-        sa.Column('description', sa.String(length=255), nullable=True),
-        sa.Column('expense_type_id', sa.Integer(), nullable=True),
-        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
-        sa.ForeignKeyConstraint(['expense_type_id'], ['expense_types.id'], ondelete='SET NULL'),
-        sa.PrimaryKeyConstraint('id'),
+        "expenses",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("amount", sa.Numeric(10, 2), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=True),
+        sa.Column("expense_type_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["expense_type_id"], ["expense_types.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
     )
     expense_types = [
-        'Sueldos',
-        'Alquiler',
-        'Luz',
-        'Gas',
-        'Agua',
-        'Internet',
-        'Impuestos',
-        'Mantenimiento',
+        "Sueldos",
+        "Alquiler",
+        "Luz",
+        "Gas",
+        "Agua",
+        "Internet",
+        "Impuestos",
+        "Mantenimiento",
     ]
     op.bulk_insert(
         sa.table(
-            'expense_types',
-            sa.column('name', sa.String),
+            "expense_types",
+            sa.column("name", sa.String),
         ),
-        [{'name': n} for n in expense_types],
+        [{"name": n} for n in expense_types],
     )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
-    op.drop_table('expenses')
-    op.drop_table('expense_types')
+    op.drop_table("expenses")
+    op.drop_table("expense_types")

--- a/app/db/repositories/expenses.py
+++ b/app/db/repositories/expenses.py
@@ -1,0 +1,36 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.expense import Expense, ExpenseType
+from app.schemas.expenses import ExpenseCreate
+
+
+class ExpensesRepository:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def list_types(self) -> list[ExpenseType]:
+        result = await self.db.execute(select(ExpenseType))
+        return result.scalars().all()
+
+    async def create_expense(self, data: ExpenseCreate) -> Expense:
+        expense = Expense(**data.model_dump())
+        self.db.add(expense)
+        await self.db.commit()
+        await self.db.refresh(expense)
+        return await self.get_expense(expense.id)
+
+    async def get_expense(self, expense_id: int) -> Expense | None:
+        result = await self.db.execute(
+            select(Expense)
+            .options(selectinload(Expense.expense_type))
+            .where(Expense.id == expense_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_expenses(self) -> list[Expense]:
+        result = await self.db.execute(
+            select(Expense).options(selectinload(Expense.expense_type))
+        )
+        return result.scalars().all()

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from app.routers import (
     auth_router,
     clients_router,
     invoice_router,
+    expenses_router,
     parts_router,
     reports_router,
     trucks_router,
@@ -101,6 +102,7 @@ def include_routers(app: FastAPI) -> None:
 
     app.include_router(trucks_router, prefix="/trucks", tags=["Camiones"])
 
+    app.include_router(expenses_router, tags=["Gastos"])
     app.include_router(parts_router, prefix="/parts", tags=["Repuestos"])
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,4 +1,5 @@
 from .clients import Client, ClientType
+from .expense import Expense, ExpenseType
 from .invoices import Invoice, InvoiceStatus, InvoiceType, Payment, PaymentMethod
 from .parts import Part
 from .trucks import Truck
@@ -16,6 +17,8 @@ __all__ = [
     "User",
     "WorkOrderPart",
     "WorkOrderTask",
+    "ExpenseType",
+    "Expense",
     "WorkOrder",
     "WorkOrderStatus",
     "WorkArea",

--- a/app/models/expense.py
+++ b/app/models/expense.py
@@ -1,4 +1,3 @@
-
 from sqlalchemy import Column, Date, DateTime, ForeignKey, Integer, Numeric, String
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func

--- a/app/models/expense.py
+++ b/app/models/expense.py
@@ -1,0 +1,32 @@
+
+from sqlalchemy import Column, Date, DateTime, ForeignKey, Integer, Numeric, String
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+
+class ExpenseType(Base):
+    __tablename__ = "expense_types"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100), unique=True, nullable=False)
+
+    expenses = relationship("Expense", back_populates="expense_type")
+
+
+class Expense(Base):
+    __tablename__ = "expenses"
+
+    id = Column(Integer, primary_key=True)
+    date = Column(Date, nullable=False)
+    amount = Column(Numeric(10, 2), nullable=False)
+    description = Column(String(255))
+    expense_type_id = Column(
+        Integer,
+        ForeignKey("expense_types.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    expense_type = relationship("ExpenseType", back_populates="expenses")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,4 +1,5 @@
 from .auth import auth_router
+from .expenses import expenses_router
 from .clients import clients_router
 from .invoices import invoice_router
 from .parts import parts_router
@@ -23,5 +24,6 @@ __all__ = [
     "trucks_router",
     "auth_router",
     "parts_router",
+    "expenses_router",
     "work_orders_reviewer_router",
 ]

--- a/app/routers/expenses.py
+++ b/app/routers/expenses.py
@@ -10,7 +10,9 @@ from app.services.expenses import ExpensesService
 expenses_router = APIRouter()
 
 
-@expenses_router.get("/expense-types", response_model=ResponseSchema[list[ExpenseTypeOut]])
+@expenses_router.get(
+    "/expense-types", response_model=ResponseSchema[list[ExpenseTypeOut]]
+)
 async def list_expense_types(db: AsyncSession = Depends(get_db)):
     service = ExpensesService(db)
     data = await service.get_expense_types()

--- a/app/routers/expenses.py
+++ b/app/routers/expenses.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.responses import success_response
+from app.schemas.expenses import ExpenseCreate, ExpenseOut, ExpenseTypeOut
+from app.schemas.response import ResponseSchema
+from app.services.expenses import ExpensesService
+
+expenses_router = APIRouter()
+
+
+@expenses_router.get("/expense-types", response_model=ResponseSchema[list[ExpenseTypeOut]])
+async def list_expense_types(db: AsyncSession = Depends(get_db)):
+    service = ExpensesService(db)
+    data = await service.get_expense_types()
+    return success_response(data=data)
+
+
+@expenses_router.get("/expenses", response_model=ResponseSchema[list[ExpenseOut]])
+async def list_expenses(db: AsyncSession = Depends(get_db)):
+    service = ExpensesService(db)
+    data = await service.list_expenses()
+    return success_response(data=data)
+
+
+@expenses_router.post("/expenses", response_model=ResponseSchema[ExpenseOut])
+async def create_expense(expense_in: ExpenseCreate, db: AsyncSession = Depends(get_db)):
+    service = ExpensesService(db)
+    data = await service.create_expense(expense_in)
+    return success_response(data=data)

--- a/app/schemas/expenses.py
+++ b/app/schemas/expenses.py
@@ -1,0 +1,28 @@
+from datetime import date, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class ExpenseTypeOut(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        from_attributes = True
+
+
+class ExpenseCreate(BaseModel):
+    date: date
+    amount: Decimal
+    description: str | None = None
+    expense_type_id: int | None
+
+
+class ExpenseOut(ExpenseCreate):
+    id: int
+    created_at: datetime
+    expense_type: ExpenseTypeOut | None = None
+
+    class Config:
+        from_attributes = True

--- a/app/services/expenses.py
+++ b/app/services/expenses.py
@@ -1,0 +1,22 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.validators import exists_or_404
+from app.db.repositories.expenses import ExpensesRepository
+from app.models.expense import Expense, ExpenseType
+from app.schemas.expenses import ExpenseCreate
+
+
+class ExpensesService:
+    def __init__(self, db: AsyncSession):
+        self.repo = ExpensesRepository(db)
+
+    async def get_expense_types(self) -> list[ExpenseType]:
+        return await self.repo.list_types()
+
+    async def create_expense(self, expense_data: ExpenseCreate) -> Expense:
+        if expense_data.expense_type_id is not None:
+            await exists_or_404(self.repo.db, ExpenseType, expense_data.expense_type_id)
+        return await self.repo.create_expense(expense_data)
+
+    async def list_expenses(self) -> list[Expense]:
+        return await self.repo.list_expenses()

--- a/tests/test_expenses.py
+++ b/tests/test_expenses.py
@@ -1,0 +1,53 @@
+import asyncio
+from datetime import date
+
+from app.models.expense import ExpenseType
+
+
+def seed_expense_type(session_factory):
+    async def run():
+        async with session_factory() as session:
+            et = ExpenseType(name="Alquiler")
+            session.add(et)
+            await session.commit()
+            await session.refresh(et)
+            return et.id
+
+    return asyncio.run(run())
+
+
+def test_create_and_list_expenses(client):
+    http, session_factory = client
+    type_id = seed_expense_type(session_factory)
+
+    resp = http.post(
+        "/expenses",
+        json={
+            "date": str(date(2024, 1, 1)),
+            "amount": "10.50",
+            "expense_type_id": type_id,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["expense_type"]["id"] == type_id
+
+    resp = http.get("/expense-types")
+    assert resp.status_code == 200
+    assert any(t["id"] == type_id for t in resp.json()["data"])
+
+    resp = http.get("/expenses")
+    assert resp.status_code == 200
+    assert any(e["id"] == data["id"] for e in resp.json()["data"])
+
+
+def test_invalid_expense_type(client):
+    http, _ = client
+    resp = http.post(
+        "/expenses",
+        json={"date": str(date(2024, 1, 1)), "amount": "5.00", "expense_type_id": 999},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert not body["success"]
+    assert body["code"] == 404


### PR DESCRIPTION
## Summary
- define `ExpenseType` and `Expense` models
- create Alembic migration for expense tables and seed data
- add schemas and service for expenses
- expose new `/expense-types` and `/expenses` endpoints
- include router and service imports in application

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687d5264d3388322a8741cd19b4ad3c0