### PR TITLE
Add OAuth token endpoint for Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,14 @@ El cuerpo sigue el esquema:
 
 En caso de error, `success` es `false` y `code` contiene el código
 correspondiente (por ejemplo 404 cuando un recurso no existe).
+
+## Uso de la documentación interactiva
+
+El esquema OAuth2 está configurado con el endpoint `POST /auth/token`.  En la
+parte superior de Swagger UI presioná **Authorize**, ingresá tus credenciales y
+obtené automáticamente el `access_token` para las siguientes peticiones.
+
+Si preferís hacerlo manualmente podés llamar a `POST /auth/login`, copiar el
+valor del campo `access_token` de la respuesta y proporcionarlo en el diálogo de
+autorización como `Bearer <token>`.  De lo contrario la documentación enviará
+el header `Authorization: Bearer undefined` y verás un `401 Token inválido`.

--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -8,7 +8,7 @@ from app.core.security import decode_token
 from app.db.repositories.users import UsersRepository
 from app.models.users import User
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
 
 
 async def get_current_user(

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -28,3 +28,18 @@ async def login(
             },
         }
     )
+
+
+@auth_router.post("/token", response_model=Token, include_in_schema=False)
+async def login_token(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: AsyncSession = Depends(get_db),
+):
+    service = AuthService(db)
+    user = await service.authenticate_user(form_data.username, form_data.password)
+    access_token = service.login_token(user)
+    return {
+        "access_token": access_token,
+        "token_type": "bearer",
+        "user": {"email": user.email, "role_id": user.role_id},
+    }


### PR DESCRIPTION
## Summary
- add `/auth/token` endpoint that returns a plain OAuth2 token
- adjust OAuth2PasswordBearer to use `/auth/token`
- document Swagger UI authorization flow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: Could not find a version)*

------
https://chatgpt.com/codex/tasks/task_e_687f0081d1308329a217533b731b70d8