### PR TITLE
Add payment summary endpoints for work order tasks

### DIFF
--- a/alembic/versions/d7e6f63ad0a5_add_paid_fields_to_work_order_tasks.py
+++ b/alembic/versions/d7e6f63ad0a5_add_paid_fields_to_work_order_tasks.py
@@ -24,10 +24,11 @@ def upgrade() -> None:
 
     bind = op.get_bind()
     if bind.dialect.name == "postgresql":
-        op.execute(
-            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_wot_area_created_paid "
-            "ON work_order_tasks (area_id, created_at, paid)"
-        )
+        with op.get_context().autocommit_block():
+            op.execute(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_wot_area_created_paid "
+                "ON work_order_tasks (area_id, created_at, paid)"
+            )
     else:
         op.create_index(
             "ix_wot_area_created_paid",
@@ -40,9 +41,10 @@ def upgrade() -> None:
 def downgrade() -> None:
     bind = op.get_bind()
     if bind.dialect.name == "postgresql":
-        op.execute(
-            "DROP INDEX CONCURRENTLY IF EXISTS ix_wot_area_created_paid"
-        )
+        with op.get_context().autocommit_block():
+            op.execute(
+                "DROP INDEX CONCURRENTLY IF EXISTS ix_wot_area_created_paid"
+            )
     else:
         op.drop_index(
             "ix_wot_area_created_paid", table_name="work_order_tasks"

--- a/alembic/versions/d7e6f63ad0a5_add_paid_fields_to_work_order_tasks.py
+++ b/alembic/versions/d7e6f63ad0a5_add_paid_fields_to_work_order_tasks.py
@@ -1,0 +1,53 @@
+"""add paid fields to work_order_tasks
+
+Revision ID: d7e6f63ad0a5
+Revises: c45d6741ac72
+Create Date: 2025-08-12 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd7e6f63ad0a5'
+down_revision: Union[str, Sequence[str], None] = 'c45d6741ac72'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("work_order_tasks") as batch_op:
+        batch_op.add_column(sa.Column("paid", sa.Boolean(), nullable=False, server_default=sa.text("false")))
+        batch_op.add_column(sa.Column("paid_at", sa.DateTime(timezone=True), nullable=True))
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_wot_area_created_paid "
+            "ON work_order_tasks (area_id, created_at, paid)"
+        )
+    else:
+        op.create_index(
+            "ix_wot_area_created_paid",
+            "work_order_tasks",
+            ["area_id", "created_at", "paid"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_wot_area_created_paid"
+        )
+    else:
+        op.drop_index(
+            "ix_wot_area_created_paid", table_name="work_order_tasks"
+        )
+
+    with op.batch_alter_table("work_order_tasks") as batch_op:
+        batch_op.drop_column("paid")
+        batch_op.drop_column("paid_at")

--- a/app/db/repositories/work_order_tasks.py
+++ b/app/db/repositories/work_order_tasks.py
@@ -1,5 +1,8 @@
+from datetime import datetime
+from typing import List
+
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.future import select
 
 from app.models.work_order_tasks import WorkOrderTask
 from app.schemas.work_order_tasks import WorkOrderTaskCreate
@@ -29,3 +32,37 @@ class WorkOrderTasksRepository:
         await self.db.delete(task)
         await self.db.commit()
         return True
+
+    async def summary(
+        self,
+        work_area_id: int,
+        date_from: datetime,
+        date_to: datetime,
+        paid: bool,
+    ) -> tuple[list[WorkOrderTask], int, float]:
+        filters = [
+            WorkOrderTask.area_id == work_area_id,
+            WorkOrderTask.created_at >= date_from,
+            WorkOrderTask.created_at <= date_to,
+            WorkOrderTask.paid == paid,
+        ]
+        result = await self.db.execute(
+            select(WorkOrderTask).where(*filters).order_by(WorkOrderTask.created_at)
+        )
+        tasks = result.scalars().all()
+        summary_result = await self.db.execute(
+            select(func.count(WorkOrderTask.id), func.coalesce(func.sum(WorkOrderTask.price), 0)).where(
+                *filters
+            )
+        )
+        count, total = summary_result.one()
+        return tasks, count, float(total)
+
+    async def mark_paid(self, task_ids: List[int], paid_at: datetime) -> int:
+        result = await self.db.execute(
+            update(WorkOrderTask)
+            .where(WorkOrderTask.id.in_(task_ids))
+            .values(paid=True, paid_at=paid_at)
+        )
+        await self.db.commit()
+        return result.rowcount

--- a/app/models/work_order_tasks.py
+++ b/app/models/work_order_tasks.py
@@ -17,6 +17,8 @@ class WorkOrderTask(Base):
     price = Column(Numeric(10, 2), nullable=False)
     external = Column(Boolean, default=False)
     created_at = Column(DateTime, default=datetime.utcnow)
+    paid = Column(Boolean, nullable=False, default=False)
+    paid_at = Column(DateTime(timezone=True), nullable=True)
 
     work_order = relationship("WorkOrder", back_populates="tasks")
     user = relationship("User")

--- a/app/routers/work_order_tasks.py
+++ b/app/routers/work_order_tasks.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends, Path
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.constants.roles import ADMIN, MECHANIC, REVISOR
@@ -6,7 +8,12 @@ from app.core.database import get_db
 from app.core.dependencies import roles_allowed
 from app.core.responses import success_response
 from app.schemas.response import ResponseSchema
-from app.schemas.work_order_tasks import WorkOrderTaskCreate, WorkOrderTaskOut
+from app.schemas.work_order_tasks import (
+    WorkOrderTaskCreate,
+    WorkOrderTaskMarkPaid,
+    WorkOrderTaskOut,
+    WorkOrderTasksSummaryOut,
+)
 from app.services.work_order_tasks import WorkOrderTasksService
 
 work_order_tasks_router = APIRouter()
@@ -46,4 +53,35 @@ async def delete_task(
 ):
     service = WorkOrderTasksService(db)
     data = await service.delete_task(task_id)
+    return success_response(data=data)
+
+
+@work_order_tasks_router.get(
+    "/summary", response_model=ResponseSchema[WorkOrderTasksSummaryOut]
+)
+async def summary_tasks(
+    date_from: date = Query(...),
+    date_to: date = Query(...),
+    work_area_id: int = Query(1),
+    paid: bool = Query(False),
+    db: AsyncSession = Depends(get_db),
+    current_user: str = Depends(roles_allowed(ADMIN, REVISOR)),
+):
+    if date_from > date_to:
+        raise HTTPException(status_code=400, detail="date_from must be <= date_to")
+    service = WorkOrderTasksService(db)
+    data = await service.summary(work_area_id, date_from, date_to, paid)
+    return success_response(data=data)
+
+
+@work_order_tasks_router.post(
+    "/mark-paid", response_model=ResponseSchema[dict]
+)
+async def mark_paid(
+    payload: WorkOrderTaskMarkPaid,
+    db: AsyncSession = Depends(get_db),
+    current_user: str = Depends(roles_allowed(ADMIN)),
+):
+    service = WorkOrderTasksService(db)
+    data = await service.mark_paid(payload)
     return success_response(data=data)

--- a/app/routers/work_order_tasks.py
+++ b/app/routers/work_order_tasks.py
@@ -31,32 +31,6 @@ async def create_task(
 
 
 @work_order_tasks_router.get(
-    "/{work_order_id}", response_model=ResponseSchema[list[WorkOrderTaskOut]]
-)
-async def list_tasks(
-    work_order_id: int = Path(..., gt=0),
-    db: AsyncSession = Depends(get_db),
-    current_user: str = Depends(roles_allowed(ADMIN, REVISOR, MECHANIC)),
-):
-    service = WorkOrderTasksService(db)
-    data = await service.list_tasks(work_order_id)
-    return success_response(data=data)
-
-
-@work_order_tasks_router.delete(
-    "/{task_id}",
-)
-async def delete_task(
-    task_id: int = Path(..., gt=0),
-    db: AsyncSession = Depends(get_db),
-    current_user: str = Depends(roles_allowed(ADMIN)),
-):
-    service = WorkOrderTasksService(db)
-    data = await service.delete_task(task_id)
-    return success_response(data=data)
-
-
-@work_order_tasks_router.get(
     "/summary", response_model=ResponseSchema[WorkOrderTasksSummaryOut]
 )
 async def summary_tasks(
@@ -84,4 +58,30 @@ async def mark_paid(
 ):
     service = WorkOrderTasksService(db)
     data = await service.mark_paid(payload)
+    return success_response(data=data)
+
+
+@work_order_tasks_router.get(
+    "/{work_order_id}", response_model=ResponseSchema[list[WorkOrderTaskOut]]
+)
+async def list_tasks(
+    work_order_id: int = Path(..., gt=0),
+    db: AsyncSession = Depends(get_db),
+    current_user: str = Depends(roles_allowed(ADMIN, REVISOR, MECHANIC)),
+):
+    service = WorkOrderTasksService(db)
+    data = await service.list_tasks(work_order_id)
+    return success_response(data=data)
+
+
+@work_order_tasks_router.delete(
+    "/{task_id}",
+)
+async def delete_task(
+    task_id: int = Path(..., gt=0),
+    db: AsyncSession = Depends(get_db),
+    current_user: str = Depends(roles_allowed(ADMIN)),
+):
+    service = WorkOrderTasksService(db)
+    data = await service.delete_task(task_id)
     return success_response(data=data)

--- a/app/schemas/work_order_tasks.py
+++ b/app/schemas/work_order_tasks.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+from datetime import date, datetime
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -19,6 +20,23 @@ class WorkOrderTaskCreate(WorkOrderTaskBase):
 class WorkOrderTaskOut(WorkOrderTaskBase):
     id: int
     created_at: datetime
+    paid: bool
+    paid_at: Optional[datetime] = None
 
     class Config:
         from_attributes = True
+
+
+class WorkOrderTasksSummaryOut(BaseModel):
+    work_area_id: int
+    date_from: date
+    date_to: date
+    paid: bool
+    count: int
+    total_amount: float
+    tasks: List[WorkOrderTaskOut]
+
+
+class WorkOrderTaskMarkPaid(BaseModel):
+    task_ids: List[int]
+    paid_at: Optional[datetime] = None

--- a/app/services/work_order_tasks.py
+++ b/app/services/work_order_tasks.py
@@ -1,3 +1,5 @@
+from datetime import date, datetime
+
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -6,7 +8,11 @@ from app.db.repositories.work_order_tasks import WorkOrderTasksRepository
 from app.models.users import User
 from app.models.work_orders import WorkOrder
 from app.models.work_orders_mechanic import WorkArea
-from app.schemas.work_order_tasks import WorkOrderTaskCreate
+from app.schemas.work_order_tasks import (
+    WorkOrderTaskCreate,
+    WorkOrderTaskMarkPaid,
+    WorkOrderTasksSummaryOut,
+)
 
 
 class WorkOrderTasksService:
@@ -32,3 +38,30 @@ class WorkOrderTasksService:
         if not deleted:
             raise HTTPException(status_code=404, detail="Tarea no encontrada")
         return {"detail": "Tarea eliminada"}
+
+    async def summary(
+        self,
+        work_area_id: int,
+        date_from: date,
+        date_to: date,
+        paid: bool,
+    ) -> WorkOrderTasksSummaryOut:
+        date_from_dt = datetime.combine(date_from, datetime.min.time())
+        date_to_dt = datetime.combine(date_to, datetime.max.time())
+        tasks, count, total = await self.repo.summary(
+            work_area_id, date_from_dt, date_to_dt, paid
+        )
+        return WorkOrderTasksSummaryOut(
+            work_area_id=work_area_id,
+            date_from=date_from,
+            date_to=date_to,
+            paid=paid,
+            count=count,
+            total_amount=total,
+            tasks=tasks,
+        )
+
+    async def mark_paid(self, data: WorkOrderTaskMarkPaid) -> dict:
+        paid_at = data.paid_at or datetime.utcnow()
+        updated = await self.repo.mark_paid(data.task_ids, paid_at)
+        return {"updated": updated}

--- a/tests/test_work_order_tasks_summary.py
+++ b/tests/test_work_order_tasks_summary.py
@@ -1,0 +1,113 @@
+import asyncio
+import os
+import tempfile
+from datetime import datetime
+
+from alembic import command
+from alembic.config import Config
+from app.models.clients import Client, ClientType
+from app.models.trucks import Truck
+from app.models.users import Role, User
+from app.models.work_orders import WorkOrder, WorkOrderStatus
+from app.models.work_order_tasks import WorkOrderTask
+from app.models.work_orders_mechanic import WorkArea
+
+
+def test_migration_upgrade_and_downgrade():
+    cfg = Config("alembic.ini")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+        command.upgrade(cfg, "head")
+        command.downgrade(cfg, "base")
+
+
+def test_summary_no_tasks(client):
+    http, _ = client
+    resp = http.get(
+        "/work-orders/tasks/summary",
+        params={"date_from": "2025-01-01", "date_to": "2025-01-31", "work_area_id": 1},
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["count"] == 0
+    assert data["total_amount"] == 0
+
+
+def test_summary_and_mark_paid(client):
+    http, session_factory = client
+
+    async def seed_data():
+        async with session_factory() as session:
+            role = Role(name="tasker")
+            area = WorkArea(name="area")
+            cli = Client(type=ClientType.persona, name="Owner")
+            session.add_all([role, area, cli])
+            await session.flush()
+            user = User(
+                name="Worker", email="w@example.com", password="x", role_id=role.id
+            )
+            session.add(user)
+            truck = Truck(client_id=cli.id, license_plate="TASK2")
+            session.add(truck)
+            status = WorkOrderStatus(name="open")
+            session.add(status)
+            await session.flush()
+            order = WorkOrder(truck_id=truck.id, status_id=status.id)
+            session.add(order)
+            await session.flush()
+            t1 = WorkOrderTask(
+                work_order_id=order.id,
+                user_id=user.id,
+                area_id=area.id,
+                description="t1",
+                price=10,
+                created_at=datetime(2025, 8, 1, 10, 0, 0),
+            )
+            t2 = WorkOrderTask(
+                work_order_id=order.id,
+                user_id=user.id,
+                area_id=area.id,
+                description="t2",
+                price=20,
+                created_at=datetime(2025, 8, 2, 12, 0, 0),
+            )
+            session.add_all([t1, t2])
+            await session.commit()
+            await session.refresh(t1)
+            await session.refresh(t2)
+            return area.id, [t1.id, t2.id]
+
+    area_id, task_ids = asyncio.run(seed_data())
+
+    resp = http.get(
+        "/work-orders/tasks/summary",
+        params={
+            "work_area_id": area_id,
+            "date_from": "2025-08-01",
+            "date_to": "2025-08-03",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["count"] == 2
+    assert data["total_amount"] == 30.0
+
+    resp = http.post(
+        "/work-orders/tasks/mark-paid",
+        json={"task_ids": task_ids, "paid_at": "2025-08-12T00:00:00Z"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["updated"] == 2
+
+    resp = http.get(
+        "/work-orders/tasks/summary",
+        params={
+            "work_area_id": area_id,
+            "date_from": "2025-08-01",
+            "date_to": "2025-08-03",
+        },
+    )
+    data = resp.json()["data"]
+    assert data["count"] == 0
+    assert data["total_amount"] == 0


### PR DESCRIPTION
## Summary
- add paid and paid_at fields to work order tasks with Alembic migration
- expose payment fields in schemas and implement summary and mark-paid endpoints
- add repository and service logic with tests for summary and payment update

## Testing
- `pre-commit run --files app/models/work_order_tasks.py app/schemas/work_order_tasks.py app/db/repositories/work_order_tasks.py app/services/work_order_tasks.py app/routers/work_order_tasks.py alembic/versions/d7e6f63ad0a5_add_paid_fields_to_work_order_tasks.py tests/test_work_order_tasks_summary.py` *(fails: command not found: pre-commit)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_e_689aa2f48d4883229d76617bf42b3a58