### PR TITLE
feat: report unpaid air mechanic tasks

### DIFF
--- a/app/routers/reports.py
+++ b/app/routers/reports.py
@@ -21,6 +21,18 @@ async def report_profit_by_order(
     return success_response(data=data)
 
 
+@reports_router.get(
+    "/unpaid-air-mechanic-tasks", response_model=ResponseSchema
+)
+async def report_unpaid_air_mechanic_tasks(
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(roles_allowed(ADMIN, REVISOR)),
+):
+    service = ReportsService(db)
+    data = await service.unpaid_air_mechanic_tasks_total()
+    return success_response(data=data)
+
+
 @reports_router.get("/billing-by-client", response_model=ResponseSchema)
 async def report_billing_by_client(
     start_date: str | None = None,

--- a/app/services/reports.py
+++ b/app/services/reports.py
@@ -29,6 +29,23 @@ class ReportsService:
         result = await self.db.execute(query)
         return [dict(row) for row in result.mappings().all()]
 
+    async def unpaid_air_mechanic_tasks_total(self):
+        query = text(
+            """
+            SELECT
+              COALESCE(SUM(wot.price), 0) AS total
+            FROM work_order_tasks wot
+            JOIN work_orders wo ON wo.id = wot.work_order_id
+            WHERE wot.area_id = :area_id
+              AND wo.status_id = :status_id
+              AND wot.paid = FALSE;
+            """
+        )
+        params = {"area_id": 1, "status_id": 3}
+        result = await self.db.execute(query, params)
+        total = result.scalar() or 0
+        return {"total": float(total)}
+
     async def billing_by_client(
         self, start_date: str | None = None, end_date: str | None = None
     ):


### PR DESCRIPTION
## Summary
- add service method to aggregate unpaid air mechanic tasks
- expose `/reports/unpaid-air-mechanic-tasks` endpoint

## Testing
- `pre-commit run --files app/services/reports.py app/routers/reports.py` *(fails: command not found)*
- `pytest` *(fails: requires httpx)*

------
https://chatgpt.com/codex/tasks/task_e_689bb27bd64883228faf47193187b1e0