### PR TITLE
feat: allow updating work order tasks and parts

### DIFF
--- a/app/db/repositories/work_order_parts.py
+++ b/app/db/repositories/work_order_parts.py
@@ -42,6 +42,16 @@ class WorkOrderPartsRepository:
 
         return result.scalar_one_or_none()
 
+    async def update(self, part_id: int, data: dict) -> WorkOrderPart | None:
+        part = await self.get(part_id)
+        if not part:
+            return None
+        for key, value in data.items():
+            setattr(part, key, value)
+        await self.db.commit()
+        await self.db.refresh(part)
+        return await self.get(part.id)
+
     async def list_names(self) -> list[str]:
         result = await self.db.execute(select(WorkOrderPart.name))
         return [row[0] for row in result.fetchall()]

--- a/app/db/repositories/work_order_tasks.py
+++ b/app/db/repositories/work_order_tasks.py
@@ -22,6 +22,22 @@ class WorkOrderTasksRepository:
         )
         return result.scalars().all()
 
+    async def get(self, task_id: int) -> WorkOrderTask | None:
+        result = await self.db.execute(
+            select(WorkOrderTask).where(WorkOrderTask.id == task_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def update(self, task_id: int, data: dict) -> WorkOrderTask | None:
+        task = await self.get(task_id)
+        if not task:
+            return None
+        for key, value in data.items():
+            setattr(task, key, value)
+        await self.db.commit()
+        await self.db.refresh(task)
+        return task
+
     async def delete(self, task_id: int) -> bool:
         task = await self.db.get(WorkOrderTask, task_id)
         if not task:

--- a/app/routers/work_order_parts.py
+++ b/app/routers/work_order_parts.py
@@ -6,7 +6,11 @@ from app.core.database import get_db
 from app.core.dependencies import roles_allowed
 from app.core.responses import success_response
 from app.schemas.response import ResponseSchema
-from app.schemas.work_order_parts import WorkOrderPartCreate, WorkOrderPartOut
+from app.schemas.work_order_parts import (
+    WorkOrderPartCreate,
+    WorkOrderPartOut,
+    WorkOrderPartUpdate,
+)
 from app.services.work_order_parts import WorkOrderPartsService
 
 work_order_parts_router = APIRouter()
@@ -43,6 +47,20 @@ async def list_parts(
 ):
     service = WorkOrderPartsService(db)
     data = await service.list_parts(work_order_id)
+    return success_response(data=data)
+
+
+@work_order_parts_router.put(
+    "/{part_id}", response_model=ResponseSchema[WorkOrderPartOut]
+)
+async def update_part(
+    part_id: int = Path(..., gt=0),
+    part_in: WorkOrderPartUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: str = Depends(roles_allowed(ADMIN, REVISOR, MECHANIC)),
+):
+    service = WorkOrderPartsService(db)
+    data = await service.update_part(part_id, part_in)
     return success_response(data=data)
 
 

--- a/app/routers/work_order_tasks.py
+++ b/app/routers/work_order_tasks.py
@@ -6,7 +6,7 @@ from app.core.database import get_db
 from app.core.dependencies import roles_allowed
 from app.core.responses import success_response
 from app.schemas.response import ResponseSchema
-from app.schemas.work_order_tasks import WorkOrderTaskCreate, WorkOrderTaskOut
+from app.schemas.work_order_tasks import WorkOrderTaskCreate, WorkOrderTaskOut, WorkOrderTaskUpdate
 from app.services.work_order_tasks import WorkOrderTasksService
 
 work_order_tasks_router = APIRouter()
@@ -33,6 +33,18 @@ async def list_tasks(
 ):
     service = WorkOrderTasksService(db)
     data = await service.list_tasks(work_order_id)
+    return success_response(data=data)
+
+
+@work_order_tasks_router.put("/{task_id}", response_model=ResponseSchema[WorkOrderTaskOut])
+async def update_task(
+    task_id: int = Path(..., gt=0),
+    task_in: WorkOrderTaskUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: str = Depends(roles_allowed(ADMIN, REVISOR, MECHANIC)),
+):
+    service = WorkOrderTasksService(db)
+    data = await service.update_task(task_id, task_in)
     return success_response(data=data)
 
 

--- a/app/schemas/work_order_parts.py
+++ b/app/schemas/work_order_parts.py
@@ -14,6 +14,15 @@ class WorkOrderPartCreate(WorkOrderPartBase):
     pass
 
 
+class WorkOrderPartUpdate(BaseModel):
+    work_order_id: int | None = None
+    name: str | None = None
+    quantity: int | None = None
+    unit_price: float | None = None
+    subtotal: float | None = None
+    increment_per_unit: float | None = None
+
+
 class WorkOrderPartOut(WorkOrderPartBase):
     id: int
 

--- a/app/schemas/work_order_tasks.py
+++ b/app/schemas/work_order_tasks.py
@@ -17,6 +17,16 @@ class WorkOrderTaskCreate(WorkOrderTaskBase):
     pass
 
 
+class WorkOrderTaskUpdate(BaseModel):
+    work_order_id: int | None = None
+    user_id: int | None = None
+    description: str | None = None
+    area_id: int | None = None
+    price: float | None = None
+    external: bool | None = None
+    paid: bool | None = None
+
+
 class WorkOrderTaskOut(WorkOrderTaskBase):
     id: int
     created_at: datetime

--- a/app/services/work_order_parts.py
+++ b/app/services/work_order_parts.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.validators import validate_foreign_keys
 from app.db.repositories.work_order_parts import WorkOrderPartsRepository
 from app.models.work_orders import WorkOrder
-from app.schemas.work_order_parts import WorkOrderPartCreate
+from app.schemas.work_order_parts import WorkOrderPartCreate, WorkOrderPartUpdate
 
 
 class WorkOrderPartsService:
@@ -20,6 +20,13 @@ class WorkOrderPartsService:
 
     async def list_parts(self, work_order_id: int):
         return await self.repo.list_by_work_order(work_order_id)
+
+    async def update_part(self, part_id: int, data: WorkOrderPartUpdate):
+        await validate_foreign_keys(self.repo.db, {WorkOrder: data.work_order_id})
+        updated = await self.repo.update(part_id, data.dict(exclude_unset=True))
+        if not updated:
+            raise HTTPException(status_code=404, detail="Repuesto no encontrado")
+        return updated
 
     async def delete_part(self, part_id: int):
         deleted = await self.repo.delete(part_id)

--- a/app/services/work_order_tasks.py
+++ b/app/services/work_order_tasks.py
@@ -6,7 +6,7 @@ from app.db.repositories.work_order_tasks import WorkOrderTasksRepository
 from app.models.users import User
 from app.models.work_orders import WorkOrder
 from app.models.work_orders_mechanic import WorkArea
-from app.schemas.work_order_tasks import WorkOrderTaskCreate
+from app.schemas.work_order_tasks import WorkOrderTaskCreate, WorkOrderTaskUpdate
 
 
 class WorkOrderTasksService:
@@ -26,6 +26,20 @@ class WorkOrderTasksService:
 
     async def list_tasks(self, work_order_id: int):
         return await self.repo.list_by_work_order(work_order_id)
+
+    async def update_task(self, task_id: int, data: WorkOrderTaskUpdate):
+        await validate_foreign_keys(
+            self.repo.db,
+            {
+                WorkOrder: data.work_order_id,
+                User: data.user_id,
+                WorkArea: data.area_id,
+            },
+        )
+        updated = await self.repo.update(task_id, data.dict(exclude_unset=True))
+        if not updated:
+            raise HTTPException(status_code=404, detail="Tarea no encontrada")
+        return updated
 
     async def delete_task(self, task_id: int):
         deleted = await self.repo.delete(task_id)

--- a/tests/test_work_order_parts.py
+++ b/tests/test_work_order_parts.py
@@ -1,3 +1,6 @@
+import asyncio
+
+
 def test_add_work_order_invalid_fk(client):
     http, _ = client
     resp = http.post(
@@ -15,3 +18,64 @@ def test_add_work_order_invalid_fk(client):
     data = resp.json()
     assert not data["success"]
     assert data["code"] == 404
+
+
+def test_part_flow(client):
+    http, session_factory = client
+
+    async def seed_data():
+        async with session_factory() as session:
+            from app.models.clients import Client, ClientType
+            from app.models.trucks import Truck
+            from app.models.work_orders import WorkOrder, WorkOrderStatus
+
+            cli = Client(type=ClientType.persona, name="Owner")
+            session.add(cli)
+            await session.flush()
+            truck = Truck(client_id=cli.id, license_plate="PART1")
+            session.add(truck)
+            status = WorkOrderStatus(name="open")
+            session.add(status)
+            await session.flush()
+            order = WorkOrder(truck_id=truck.id, status_id=status.id)
+            session.add(order)
+            await session.commit()
+            await session.refresh(order)
+            return order.id
+
+    order_id = asyncio.run(seed_data())
+    resp = http.post(
+        "/work-orders/parts/",
+        json={
+            "work_order_id": order_id,
+            "quantity": 1,
+            "name": "Part",
+            "unit_price": 5,
+            "subtotal": 5,
+            "increment_per_unit": 0,
+        },
+    )
+    assert resp.status_code == 200
+    part_id = resp.json()["data"]["id"]
+
+    resp = http.put(
+        f"/work-orders/parts/{part_id}",
+        json={"quantity": 2, "unit_price": 7, "subtotal": 14},
+    )
+    assert resp.status_code == 200
+    updated = resp.json()["data"]
+    assert updated["quantity"] == 2
+    assert updated["unit_price"] == 7
+
+    resp = http.get(f"/work-orders/parts/{order_id}")
+    assert resp.status_code == 200
+    parts = resp.json()["data"]
+    assert next(p for p in parts if p["id"] == part_id)["quantity"] == 2
+
+    resp = http.delete(f"/work-orders/parts/{part_id}")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["detail"] == "Repuesto eliminado"
+
+    resp = http.get(f"/work-orders/parts/{order_id}")
+    assert resp.status_code == 200
+    assert len(resp.json()["data"]) == 0

--- a/tests/test_work_order_tasks.py
+++ b/tests/test_work_order_tasks.py
@@ -75,6 +75,20 @@ def test_task_flow(client):
     assert any(t["id"] == task_id for t in tasks)
     assert next(t for t in tasks if t["id"] == task_id)["paid"] is False
 
+    resp = http.put(
+        f"/work-orders/tasks/{task_id}",
+        json={"price": 15.0, "paid": True},
+    )
+    assert resp.status_code == 200
+    updated = resp.json()["data"]
+    assert updated["price"] == 15.0
+    assert updated["paid"] is True
+
+    resp = http.get(f"/work-orders/tasks/{order_id}")
+    assert resp.status_code == 200
+    tasks = resp.json()["data"]
+    assert next(t for t in tasks if t["id"] == task_id)["paid"] is True
+
     resp = http.delete(f"/work-orders/tasks/{task_id}")
     assert resp.status_code == 200
     assert resp.json()["data"]["detail"] == "Tarea eliminada"


### PR DESCRIPTION
## Summary
- add WorkOrderTaskUpdate and WorkOrderPartUpdate schemas
- enable updating tasks and parts in repositories, services, and routers
- cover task and part update flows with tests

## Testing
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed. Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_e_689cc97467b8832995968b143fb509bd