### PR TITLE
feat: bulk update paid flag for WorkOrderTask

### DIFF
--- a/app/db/repositories/work_order_tasks.py
+++ b/app/db/repositories/work_order_tasks.py
@@ -45,3 +45,19 @@ class WorkOrderTasksRepository:
         await self.db.delete(task)
         await self.db.commit()
         return True
+
+    async def bulk_update_paid(
+        self, task_ids: list[int], paid: bool
+    ) -> list[WorkOrderTask] | None:
+        result = await self.db.execute(
+            select(WorkOrderTask).where(WorkOrderTask.id.in_(task_ids))
+        )
+        tasks = result.scalars().all()
+        if len(tasks) != len(task_ids):
+            return None
+        for task in tasks:
+            task.paid = paid
+        await self.db.commit()
+        for task in tasks:
+            await self.db.refresh(task)
+        return tasks

--- a/app/routers/work_order_tasks.py
+++ b/app/routers/work_order_tasks.py
@@ -28,6 +28,19 @@ async def create_task(
     return success_response(data=data)
 
 
+@work_order_tasks_router.put(
+    "/bulk-paid", response_model=ResponseSchema[list[WorkOrderTaskOut]]
+)
+async def bulk_update_paid(
+    tasks_in: WorkOrderTaskBulkPaidUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: str = Depends(roles_allowed(ADMIN, REVISOR)),
+):
+    service = WorkOrderTasksService(db)
+    data = await service.bulk_update_paid(tasks_in)
+    return success_response(data=data)
+
+
 @work_order_tasks_router.get(
     "/{work_order_id}", response_model=ResponseSchema[list[WorkOrderTaskOut]]
 )
@@ -65,17 +78,4 @@ async def delete_task(
 ):
     service = WorkOrderTasksService(db)
     data = await service.delete_task(task_id)
-    return success_response(data=data)
-
-
-@work_order_tasks_router.put(
-    "/bulk-paid", response_model=ResponseSchema[list[WorkOrderTaskOut]]
-)
-async def bulk_update_paid(
-    tasks_in: WorkOrderTaskBulkPaidUpdate,
-    db: AsyncSession = Depends(get_db),
-    current_user: str = Depends(roles_allowed(ADMIN, REVISOR)),
-):
-    service = WorkOrderTasksService(db)
-    data = await service.bulk_update_paid(tasks_in)
     return success_response(data=data)

--- a/app/routers/work_order_tasks.py
+++ b/app/routers/work_order_tasks.py
@@ -8,6 +8,7 @@ from app.core.responses import success_response
 from app.schemas.response import ResponseSchema
 from app.schemas.work_order_tasks import (
     WorkOrderTaskCreate,
+    WorkOrderTaskBulkPaidUpdate,
     WorkOrderTaskOut,
     WorkOrderTaskUpdate,
 )
@@ -64,4 +65,17 @@ async def delete_task(
 ):
     service = WorkOrderTasksService(db)
     data = await service.delete_task(task_id)
+    return success_response(data=data)
+
+
+@work_order_tasks_router.put(
+    "/bulk-paid", response_model=ResponseSchema[list[WorkOrderTaskOut]]
+)
+async def bulk_update_paid(
+    tasks_in: WorkOrderTaskBulkPaidUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: str = Depends(roles_allowed(ADMIN, REVISOR)),
+):
+    service = WorkOrderTasksService(db)
+    data = await service.bulk_update_paid(tasks_in)
     return success_response(data=data)

--- a/app/schemas/work_order_tasks.py
+++ b/app/schemas/work_order_tasks.py
@@ -27,6 +27,11 @@ class WorkOrderTaskUpdate(BaseModel):
     paid: bool | None = None
 
 
+class WorkOrderTaskBulkPaidUpdate(BaseModel):
+    task_ids: list[int]
+    paid: bool
+
+
 class WorkOrderTaskOut(WorkOrderTaskBase):
     id: int
     created_at: datetime

--- a/app/services/work_order_tasks.py
+++ b/app/services/work_order_tasks.py
@@ -8,7 +8,11 @@ from app.models.users import User
 from app.models.work_orders import WorkOrder
 from app.models.work_orders_mechanic import WorkArea
 from app.models.invoices import Invoice
-from app.schemas.work_order_tasks import WorkOrderTaskCreate, WorkOrderTaskUpdate
+from app.schemas.work_order_tasks import (
+    WorkOrderTaskBulkPaidUpdate,
+    WorkOrderTaskCreate,
+    WorkOrderTaskUpdate,
+)
 
 
 class WorkOrderTasksService:
@@ -66,3 +70,9 @@ class WorkOrderTasksService:
         if not deleted:
             raise HTTPException(status_code=404, detail="Tarea no encontrada")
         return {"detail": "Tarea eliminada"}
+
+    async def bulk_update_paid(self, data: WorkOrderTaskBulkPaidUpdate):
+        tasks = await self.repo.bulk_update_paid(data.task_ids, data.paid)
+        if tasks is None:
+            raise HTTPException(status_code=404, detail="Tarea no encontrada")
+        return tasks


### PR DESCRIPTION
## Summary
- add repository method to update paid flag across multiple tasks in one commit
- expose service and router endpoint for bulk paid updates
- define schema for bulk paid update payload

## Testing
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689d41e239088322aae2f22bafb7a502