### PR TITLE
Enable ORM serialization for payment outputs

### DIFF
--- a/app/routers/invoices.py
+++ b/app/routers/invoices.py
@@ -65,7 +65,7 @@ async def register_payment(
 ):
     service = PaymentsService(db)
     payment = await service.create(payment_in)
-    data = PaymentOut.model_validate(payment).model_dump()
+    data = PaymentOut.model_validate(payment, from_attributes=True).model_dump()
     return success_response(data=data)
 
 

--- a/app/schemas/invoices.py
+++ b/app/schemas/invoices.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from app.models.invoices import BankCheckType
 
@@ -85,16 +85,14 @@ class BankCheckOut(BankCheckIn):
     issued_at: datetime
     exchange_date: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class PaymentMethodOut(BaseModel):
     id: int
     name: str
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class BankCheckExchange(BaseModel):
@@ -110,15 +108,8 @@ class InvoiceDetailOut(InvoiceOut):
 class PaymentOut(PaymentCreate):
     id: int
     date: datetime
-    method_id: int
-
-    class Config:
-        from_attributes = True
-
-
-class PaymentOutDetail(PaymentOut):
     method: PaymentMethodOut
     bank_checks: list[BankCheckOut] | None = None
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
+


### PR DESCRIPTION
## Summary
- enable Pydantic ORM mode for payment-related response models
- include payment method and bank checks in payment output
- serialize payments from ORM objects in register_payment endpoint

## Testing
- `pre-commit run --files app/schemas/invoices.py app/routers/invoices.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(fails: RuntimeError: The starlette.testclient module requires the httpx package to be installed)*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*


------
https://chatgpt.com/codex/tasks/task_e_68a505bf0fb483228aa555f0a498a1b2