### PR TITLE
Configure PostgreSQL timezone for async engine

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -7,7 +7,11 @@ from sqlalchemy.orm import sessionmaker
 from app.core.settings import settings
 
 # Asegurate que tu DATABASE_URL sea asíncrona: postgresql+asyncpg://...
-engine = create_async_engine(settings.DATABASE_URL, echo=True)
+engine = create_async_engine(
+    settings.DATABASE_URL,
+    echo=True,
+    connect_args={"options": "-c timezone=America/Argentina/Buenos_Aires"},
+)
 
 AsyncSessionLocal = sessionmaker(
     bind=engine, class_=AsyncSession, expire_on_commit=False


### PR DESCRIPTION
## Summary
- set `America/Argentina/Buenos_Aires` timezone when creating the async engine

## Testing
- `pre-commit run --files app/core/database.py` *(fails: command not found)*
- `pytest` *(fails: starlette.testclient requires httpx package)*

------
https://chatgpt.com/codex/tasks/task_e_68a50b3c3a848322af586ae83c6a5654