### PR TITLE
Add invoice details to payment search

### DIFF
--- a/app/db/repositories/invoices.py
+++ b/app/db/repositories/invoices.py
@@ -162,6 +162,9 @@ class PaymentsRepository:
         query = select(Payment).options(
             selectinload(Payment.bank_checks),
             selectinload(Payment.method),
+            selectinload(Payment.invoice).selectinload(Invoice.client),
+            selectinload(Payment.invoice).selectinload(Invoice.invoice_type),
+            selectinload(Payment.invoice).selectinload(Invoice.status),
         )
         if client_id is not None:
             query = query.join(Payment.invoice).where(Invoice.client_id == client_id)

--- a/app/routers/invoices.py
+++ b/app/routers/invoices.py
@@ -15,6 +15,7 @@ from app.schemas.invoices import (
     PaymentCreate,
     PaymentMethodOut,
     PaymentOut,
+    PaymentSearchOut,
 )
 from app.schemas.response import ResponseSchema
 from app.services.invoices import BankChecksService, InvoicesService, PaymentsService
@@ -69,7 +70,7 @@ async def register_payment(
     return success_response(data=data)
 
 
-@invoice_router.get("/payments/", response_model=ResponseSchema[list[PaymentOut]])
+@invoice_router.get("/payments/", response_model=ResponseSchema[list[PaymentSearchOut]])
 async def search_payments(
     client_id: int | None = None,
     invoice_id: int | None = None,
@@ -79,9 +80,13 @@ async def search_payments(
     current_user: str = Depends(roles_allowed(ADMIN, REVISOR)),
 ):
     service = PaymentsService(db)
-    data = await service.list(
+    payments = await service.list(
         client_id=client_id, invoice_id=invoice_id, skip=skip, limit=limit
     )
+    data = [
+        PaymentSearchOut.model_validate(payment, from_attributes=True).model_dump()
+        for payment in payments
+    ]
     return success_response(data=data)
 
 

--- a/app/schemas/invoices.py
+++ b/app/schemas/invoices.py
@@ -113,3 +113,21 @@ class PaymentOut(PaymentCreate):
 
     model_config = ConfigDict(from_attributes=True)
 
+
+class InvoiceForPaymentOut(InvoiceCreate):
+    id: int
+    issued_at: datetime
+    paid: float
+    accepted: bool
+    client: ClientOut
+    status: InvoiceStatus
+    invoice_type: InvoiceTypeFull
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PaymentSearchOut(PaymentOut):
+    invoice: InvoiceForPaymentOut
+
+    model_config = ConfigDict(from_attributes=True)
+


### PR DESCRIPTION
## Summary
- add `InvoiceForPaymentOut` and `PaymentSearchOut` schemas
- eagerly load invoice relations in `PaymentsRepository.list`
- return invoice details with payments and update tests

## Testing
- `pytest tests/test_payments.py::test_search_payments_includes_invoice_and_client -q` *(fails: httpx missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a50ce67110832286a1f880914c9038