### PR TITLE
feat: filter orders by status

### DIFF
--- a/app/db/repositories/work_orders.py
+++ b/app/db/repositories/work_orders.py
@@ -32,8 +32,10 @@ class WorkOrdersRepository:
         )
         return result.scalar_one_or_none()
 
-    async def list(self, skip: int = 0, limit: int = 100) -> list[WorkOrder]:
-        result = await self.db.execute(
+    async def list(
+        self, skip: int = 0, limit: int = 100, status_id: int | None = None
+    ) -> list[WorkOrder]:
+        query = (
             select(WorkOrder)
             .options(
                 selectinload(WorkOrder.status),
@@ -46,6 +48,9 @@ class WorkOrdersRepository:
             .offset(skip)
             .limit(limit)
         )
+        if status_id is not None:
+            query = query.where(WorkOrder.status_id == status_id)
+        result = await self.db.execute(query)
         return result.scalars().all()
 
     async def update(self, work_order_id: int, data: dict) -> WorkOrder | bool:

--- a/app/routers/work_orders.py
+++ b/app/routers/work_orders.py
@@ -27,11 +27,12 @@ async def create_order(
 async def list_orders(
     skip: int = 0,
     limit: int = 100,
+    status_id: int | None = None,
     db: AsyncSession = Depends(get_db),
     current_user: str = Depends(roles_allowed(ADMIN, REVISOR, MECHANIC)),
 ):
     service = WorkOrdersService(db)
-    orders = await service.list_work_orders(skip=skip, limit=limit)
+    orders = await service.list_work_orders(skip=skip, limit=limit, status_id=status_id)
     return success_response(data=orders)
 
 

--- a/app/services/work_orders.py
+++ b/app/services/work_orders.py
@@ -43,8 +43,10 @@ class WorkOrdersService:
             raise HTTPException(status_code=404, detail="Orden no encontrada")
         return await self._add_editable(work_order)
 
-    async def list_work_orders(self, skip: int = 0, limit: int = 100):
-        orders = await self.repo.list(skip=skip, limit=limit)
+    async def list_work_orders(
+        self, skip: int = 0, limit: int = 100, status_id: int | None = None
+    ):
+        orders = await self.repo.list(skip=skip, limit=limit, status_id=status_id)
         return [await self._add_editable(o) for o in orders]
 
     async def update_work_order(self, work_order_id: int, data: WorkOrderUpdate):


### PR DESCRIPTION
## Summary
- allow listing work orders filtered by status
- cover order status filtering with tests

## Testing
- `black app/routers/work_orders.py app/services/work_orders.py app/db/repositories/work_orders.py tests/test_work_orders.py`
- `isort --check-only -v app/routers/work_orders.py app/services/work_orders.py app/db/repositories/work_orders.py tests/test_work_orders.py`
- `flake8 app/routers/work_orders.py app/services/work_orders.py app/db/repositories/work_orders.py tests/test_work_orders.py` *(fails: command not found)*
- `pytest tests/test_work_orders.py::test_list_orders_by_status -q` *(fails: missing httpx dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a54608b1d88322a1ad03d69017490d