### PR TITLE
Sort work orders by newest first

### DIFF
--- a/app/db/repositories/work_orders.py
+++ b/app/db/repositories/work_orders.py
@@ -45,6 +45,7 @@ class WorkOrdersRepository:
                 selectinload(WorkOrder.tasks),
                 selectinload(WorkOrder.parts),
             )
+            .order_by(WorkOrder.id.desc())
             .offset(skip)
             .limit(limit)
         )


### PR DESCRIPTION
## Summary
- return latest work orders first in listings

## Testing
- `pytest` *(fails: ImportError: httpx package required, environment missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a552bdf97083229d2d19b60788841b