### PR TITLE
feat: filter and sort invoices

### DIFF
--- a/app/db/repositories/invoices.py
+++ b/app/db/repositories/invoices.py
@@ -35,17 +35,23 @@ class InvoicesRepository:
         )
         return result.scalar_one_or_none()
 
-    async def list(self, skip: int = 0, limit: int = 100) -> list[Invoice]:
-        result = await self.db.execute(
+    async def list(
+        self, skip: int = 0, limit: int = 100, status_id: int | None = None
+    ) -> list[Invoice]:
+        query = (
             select(Invoice)
             .options(
                 selectinload(Invoice.client),
                 selectinload(Invoice.invoice_type),
                 selectinload(Invoice.status),
             )
+            .order_by(Invoice.id.desc())
             .offset(skip)
             .limit(limit)
         )
+        if status_id is not None:
+            query = query.where(Invoice.status_id == status_id)
+        result = await self.db.execute(query)
         return result.scalars().all()
 
     async def update(self, id: int, data: InvoiceUpdate) -> Invoice:

--- a/app/routers/invoices.py
+++ b/app/routers/invoices.py
@@ -38,11 +38,12 @@ async def create_invoice(
 async def list_invoices(
     skip: int = 0,
     limit: int = 100,
+    status_id: int | None = None,
     db: AsyncSession = Depends(get_db),
     current_user: str = Depends(roles_allowed(ADMIN, REVISOR)),
 ):
     service = InvoicesService(db)
-    data = await service.list(skip=skip, limit=limit)
+    data = await service.list(skip=skip, limit=limit, status_id=status_id)
     return success_response(data=data)
 
 

--- a/app/services/invoices.py
+++ b/app/services/invoices.py
@@ -63,8 +63,8 @@ class InvoicesService:
         invoice = await self.get(invoice_id)
         return _invoice_with_surcharge(invoice)
 
-    async def list(self, skip: int = 0, limit: int = 100):
-        return await self.repo.list(skip=skip, limit=limit)
+    async def list(self, skip: int = 0, limit: int = 100, status_id: int | None = None):
+        return await self.repo.list(skip=skip, limit=limit, status_id=status_id)
 
     async def update(self, invoice_id: int, data: InvoiceUpdate):
         await exists_or_404(self.repo.db, Invoice, invoice_id)


### PR DESCRIPTION
## Summary
- allow filtering invoices by status and return newest first
- test invoices listing order and status filter

## Testing
- `python -m black app/db/repositories/invoices.py app/routers/invoices.py app/services/invoices.py tests/test_invoices.py`
- `python -m isort --check --verbose app/db/repositories/invoices.py app/routers/invoices.py app/services/invoices.py tests/test_invoices.py`
- `pre-commit run --files app/db/repositories/invoices.py app/routers/invoices.py app/services/invoices.py tests/test_invoices.py` *(fails: command not found and package install blocked)*
- `pytest tests/test_invoices.py` *(fails: missing httpx package; installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a558ca20d483229e92d412416a31db