### PR TITLE
feat: add date and client filters

### DIFF
--- a/app/db/repositories/invoices.py
+++ b/app/db/repositories/invoices.py
@@ -36,7 +36,13 @@ class InvoicesRepository:
         return result.scalar_one_or_none()
 
     async def list(
-        self, skip: int = 0, limit: int = 100, status_id: int | None = None
+        self,
+        skip: int = 0,
+        limit: int = 100,
+        status_id: int | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        client_id: int | None = None,
     ) -> list[Invoice]:
         query = (
             select(Invoice)
@@ -51,6 +57,12 @@ class InvoicesRepository:
         )
         if status_id is not None:
             query = query.where(Invoice.status_id == status_id)
+        if start_date is not None:
+            query = query.where(Invoice.issued_at >= start_date)
+        if end_date is not None:
+            query = query.where(Invoice.issued_at <= end_date)
+        if client_id is not None:
+            query = query.where(Invoice.client_id == client_id)
         result = await self.db.execute(query)
         return result.scalars().all()
 

--- a/app/db/repositories/work_orders.py
+++ b/app/db/repositories/work_orders.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import selectinload
@@ -33,7 +35,14 @@ class WorkOrdersRepository:
         return result.scalar_one_or_none()
 
     async def list(
-        self, skip: int = 0, limit: int = 100, status_id: int | None = None
+        self,
+        skip: int = 0,
+        limit: int = 100,
+        status_id: int | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        client_id: int | None = None,
+        truck_id: int | None = None,
     ) -> list[WorkOrder]:
         query = (
             select(WorkOrder)
@@ -51,6 +60,14 @@ class WorkOrdersRepository:
         )
         if status_id is not None:
             query = query.where(WorkOrder.status_id == status_id)
+        if start_date is not None:
+            query = query.where(WorkOrder.created_at >= start_date)
+        if end_date is not None:
+            query = query.where(WorkOrder.created_at <= end_date)
+        if truck_id is not None:
+            query = query.where(WorkOrder.truck_id == truck_id)
+        if client_id is not None:
+            query = query.join(WorkOrder.truck).where(Truck.client_id == client_id)
         result = await self.db.execute(query)
         return result.scalars().all()
 

--- a/app/routers/invoices.py
+++ b/app/routers/invoices.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,11 +41,21 @@ async def list_invoices(
     skip: int = 0,
     limit: int = 100,
     status_id: int | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    client_id: int | None = None,
     db: AsyncSession = Depends(get_db),
     current_user: str = Depends(roles_allowed(ADMIN, REVISOR)),
 ):
     service = InvoicesService(db)
-    data = await service.list(skip=skip, limit=limit, status_id=status_id)
+    data = await service.list(
+        skip=skip,
+        limit=limit,
+        status_id=status_id,
+        start_date=start_date,
+        end_date=end_date,
+        client_id=client_id,
+    )
     return success_response(data=data)
 
 

--- a/app/routers/work_orders.py
+++ b/app/routers/work_orders.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from datetime import datetime
+
 from app.constants.roles import ADMIN, MECHANIC, REVISOR
 from app.core.database import get_db
 from app.core.dependencies import roles_allowed
@@ -28,11 +30,23 @@ async def list_orders(
     skip: int = 0,
     limit: int = 100,
     status_id: int | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    client_id: int | None = None,
+    truck_id: int | None = None,
     db: AsyncSession = Depends(get_db),
     current_user: str = Depends(roles_allowed(ADMIN, REVISOR, MECHANIC)),
 ):
     service = WorkOrdersService(db)
-    orders = await service.list_work_orders(skip=skip, limit=limit, status_id=status_id)
+    orders = await service.list_work_orders(
+        skip=skip,
+        limit=limit,
+        status_id=status_id,
+        start_date=start_date,
+        end_date=end_date,
+        client_id=client_id,
+        truck_id=truck_id,
+    )
     return success_response(data=orders)
 
 

--- a/app/services/invoices.py
+++ b/app/services/invoices.py
@@ -1,4 +1,6 @@
 from fastapi import HTTPException
+from datetime import datetime
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.validators import exists_or_404, validate_foreign_keys
@@ -63,8 +65,23 @@ class InvoicesService:
         invoice = await self.get(invoice_id)
         return _invoice_with_surcharge(invoice)
 
-    async def list(self, skip: int = 0, limit: int = 100, status_id: int | None = None):
-        return await self.repo.list(skip=skip, limit=limit, status_id=status_id)
+    async def list(
+        self,
+        skip: int = 0,
+        limit: int = 100,
+        status_id: int | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        client_id: int | None = None,
+    ):
+        return await self.repo.list(
+            skip=skip,
+            limit=limit,
+            status_id=status_id,
+            start_date=start_date,
+            end_date=end_date,
+            client_id=client_id,
+        )
 
     async def update(self, invoice_id: int, data: InvoiceUpdate):
         await exists_or_404(self.repo.db, Invoice, invoice_id)

--- a/app/services/invoices.py
+++ b/app/services/invoices.py
@@ -79,6 +79,12 @@ class InvoicesService:
         if end_date:
             end_date = end_date.replace(hour=23, minute=59, second=59, microsecond=999999)
 
+        if start_date and end_date and start_date > end_date:
+            raise HTTPException(
+                status_code=400,
+                detail="La fecha de inicio no puede ser mayor que la fecha final",
+            )
+
         return await self.repo.list(
             skip=skip,
             limit=limit,

--- a/app/services/invoices.py
+++ b/app/services/invoices.py
@@ -74,6 +74,11 @@ class InvoicesService:
         end_date: datetime | None = None,
         client_id: int | None = None,
     ):
+        if start_date:
+            start_date = start_date.replace(hour=0, minute=0, second=0, microsecond=0)
+        if end_date:
+            end_date = end_date.replace(hour=23, minute=59, second=59, microsecond=999999)
+
         return await self.repo.list(
             skip=skip,
             limit=limit,

--- a/app/services/work_orders.py
+++ b/app/services/work_orders.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -44,9 +46,24 @@ class WorkOrdersService:
         return await self._add_editable(work_order)
 
     async def list_work_orders(
-        self, skip: int = 0, limit: int = 100, status_id: int | None = None
+        self,
+        skip: int = 0,
+        limit: int = 100,
+        status_id: int | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        client_id: int | None = None,
+        truck_id: int | None = None,
     ):
-        orders = await self.repo.list(skip=skip, limit=limit, status_id=status_id)
+        orders = await self.repo.list(
+            skip=skip,
+            limit=limit,
+            status_id=status_id,
+            start_date=start_date,
+            end_date=end_date,
+            client_id=client_id,
+            truck_id=truck_id,
+        )
         return [await self._add_editable(o) for o in orders]
 
     async def update_work_order(self, work_order_id: int, data: WorkOrderUpdate):

--- a/app/services/work_orders.py
+++ b/app/services/work_orders.py
@@ -55,6 +55,11 @@ class WorkOrdersService:
         client_id: int | None = None,
         truck_id: int | None = None,
     ):
+        if start_date:
+            start_date = start_date.replace(hour=0, minute=0, second=0, microsecond=0)
+        if end_date:
+            end_date = end_date.replace(hour=23, minute=59, second=59, microsecond=999999)
+
         orders = await self.repo.list(
             skip=skip,
             limit=limit,

--- a/app/services/work_orders.py
+++ b/app/services/work_orders.py
@@ -60,6 +60,12 @@ class WorkOrdersService:
         if end_date:
             end_date = end_date.replace(hour=23, minute=59, second=59, microsecond=999999)
 
+        if start_date and end_date and start_date > end_date:
+            raise HTTPException(
+                status_code=400,
+                detail="La fecha de inicio no puede ser mayor que la fecha final",
+            )
+
         orders = await self.repo.list(
             skip=skip,
             limit=limit,

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -263,3 +263,52 @@ def test_list_invoices_by_client_and_date(client):
     assert resp.status_code == 200
     data = resp.json()["data"]
     assert len(data) == 1 and data[0]["id"] == inv2_id
+
+
+def test_list_invoices_date_inclusive(client):
+    http, session_factory = client
+
+    async def seed():
+        async with session_factory() as session:
+            cli = Client(type=ClientType.persona, name="DateInv")
+            session.add(cli)
+            await session.flush()
+            truck = Truck(client_id=cli.id, license_plate="INV2")
+            session.add(truck)
+            wo_status = WorkOrderStatus(name="open")
+            inv_status = InvoiceStatus(name="pending")
+            inv_type = InvoiceType(name="A", surcharge=0)
+            session.add_all([wo_status, inv_status, inv_type])
+            await session.flush()
+
+            order = WorkOrder(truck_id=truck.id, status_id=wo_status.id)
+            session.add(order)
+            await session.flush()
+
+            inv = Invoice(
+                work_order_id=order.id,
+                client_id=cli.id,
+                invoice_type_id=inv_type.id,
+                status_id=inv_status.id,
+                labor_total=0,
+                parts_total=0,
+                iva=0,
+                total=0,
+                issued_at=datetime(2023, 1, 1, 20, 0),
+            )
+            session.add(inv)
+            await session.commit()
+            await session.refresh(inv)
+            return inv.id
+
+    invoice_id = asyncio.run(seed())
+    resp = http.get(
+        "/invoices/",
+        params={
+            "start_date": datetime(2023, 1, 1).isoformat(),
+            "end_date": datetime(2023, 1, 1).isoformat(),
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert len(data) == 1 and data[0]["id"] == invoice_id

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -314,6 +314,24 @@ def test_list_invoices_end_date_inclusive(client):
     assert len(data) == 1 and data[0]["id"] == invoice_id
 
 
+def test_list_invoices_invalid_date_range(client):
+    http, _ = client
+    resp = http.get(
+        "/invoices/",
+        params={
+            "start_date": datetime(2023, 2, 1).isoformat(),
+            "end_date": datetime(2023, 1, 1).isoformat(),
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == 400
+    assert (
+        body["message"]
+        == "La fecha de inicio no puede ser mayor que la fecha final"
+    )
+
+
 def test_list_invoices_date_inclusive(client):
     http, session_factory = client
 
@@ -361,3 +379,21 @@ def test_list_invoices_date_inclusive(client):
     assert resp.status_code == 200
     data = resp.json()["data"]
     assert len(data) == 1 and data[0]["id"] == invoice_id
+
+
+def test_list_invoices_invalid_date_range(client):
+    http, _ = client
+    resp = http.get(
+        "/invoices/",
+        params={
+            "start_date": datetime(2023, 2, 1).isoformat(),
+            "end_date": datetime(2023, 1, 1).isoformat(),
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == 400
+    assert (
+        body["message"]
+        == "La fecha de inicio no puede ser mayor que la fecha final"
+    )

--- a/tests/test_work_orders.py
+++ b/tests/test_work_orders.py
@@ -312,6 +312,24 @@ def test_list_orders_end_date_inclusive(client):
     assert len(data) == 1 and data[0]["id"] == order_id
 
 
+def test_list_orders_invalid_date_range(client):
+    http, _ = client
+    resp = http.get(
+        "/orders/",
+        params={
+            "start_date": datetime(2023, 2, 1).isoformat(),
+            "end_date": datetime(2023, 1, 1).isoformat(),
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == 400
+    assert (
+        body["message"]
+        == "La fecha de inicio no puede ser mayor que la fecha final"
+    )
+
+
 def test_get_order_success(client):
     http, session_factory = client
 

--- a/tests/test_work_orders.py
+++ b/tests/test_work_orders.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime
 
 from app.models.clients import Client, ClientType
 from app.models.trucks import Truck
@@ -160,6 +161,83 @@ def test_list_orders_by_status(client):
     data = resp.json()["data"]
     assert len(data) == 1
     assert data[0]["status_id"] == status1_id
+
+
+def test_list_orders_by_client_and_truck(client):
+    http, session_factory = client
+
+    async def seed():
+        async with session_factory() as session:
+            cli1 = Client(type=ClientType.persona, name="C1")
+            cli2 = Client(type=ClientType.persona, name="C2")
+            session.add_all([cli1, cli2])
+            await session.flush()
+            truck1 = Truck(client_id=cli1.id, license_plate="AAA123")
+            truck2 = Truck(client_id=cli2.id, license_plate="BBB123")
+            session.add_all([truck1, truck2])
+            status = WorkOrderStatus(name="st")
+            session.add(status)
+            await session.flush()
+            order1 = WorkOrder(truck_id=truck1.id, status_id=status.id)
+            order2 = WorkOrder(truck_id=truck2.id, status_id=status.id)
+            session.add_all([order1, order2])
+            await session.commit()
+            return cli1.id, truck2.id, order1.id, order2.id
+
+    client_id, truck_id, order1_id, order2_id = asyncio.run(seed())
+
+    resp = http.get("/orders/", params={"client_id": client_id})
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert len(data) == 1 and data[0]["id"] == order1_id
+
+    resp = http.get("/orders/", params={"truck_id": truck_id})
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert len(data) == 1 and data[0]["id"] == order2_id
+
+
+def test_list_orders_by_date_range(client):
+    http, session_factory = client
+
+    async def seed():
+        async with session_factory() as session:
+            cli = Client(type=ClientType.persona, name="DateCli")
+            session.add(cli)
+            await session.flush()
+            truck = Truck(client_id=cli.id, license_plate="DATE1")
+            session.add(truck)
+            status = WorkOrderStatus(name="date")
+            session.add(status)
+            await session.flush()
+            old = WorkOrder(
+                truck_id=truck.id,
+                status_id=status.id,
+                created_at=datetime(2023, 1, 1),
+            )
+            new = WorkOrder(
+                truck_id=truck.id,
+                status_id=status.id,
+                created_at=datetime(2023, 2, 1),
+            )
+            session.add_all([old, new])
+            await session.commit()
+            await session.refresh(old)
+            await session.refresh(new)
+            return old.id, new.id
+
+    old_id, new_id = asyncio.run(seed())
+
+    resp = http.get(
+        "/orders/",
+        params={
+            "start_date": datetime(2023, 1, 15).isoformat(),
+            "end_date": datetime(2023, 2, 15).isoformat(),
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert len(data) == 1 and data[0]["id"] == new_id
 
 
 def test_get_order_success(client):

--- a/tests/test_work_orders.py
+++ b/tests/test_work_orders.py
@@ -240,6 +240,42 @@ def test_list_orders_by_date_range(client):
     assert len(data) == 1 and data[0]["id"] == new_id
 
 
+def test_list_orders_date_inclusive(client):
+    http, session_factory = client
+
+    async def seed():
+        async with session_factory() as session:
+            cli = Client(type=ClientType.persona, name="DateIncl")
+            session.add(cli)
+            await session.flush()
+            truck = Truck(client_id=cli.id, license_plate="DATE2")
+            session.add(truck)
+            status = WorkOrderStatus(name="date")
+            session.add(status)
+            await session.flush()
+            order = WorkOrder(
+                truck_id=truck.id,
+                status_id=status.id,
+                created_at=datetime(2023, 1, 1, 15, 30),
+            )
+            session.add(order)
+            await session.commit()
+            await session.refresh(order)
+            return order.id
+
+    order_id = asyncio.run(seed())
+    resp = http.get(
+        "/orders/",
+        params={
+            "start_date": datetime(2023, 1, 1).isoformat(),
+            "end_date": datetime(2023, 1, 1).isoformat(),
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert len(data) == 1 and data[0]["id"] == order_id
+
+
 def test_get_order_success(client):
     http, session_factory = client
 


### PR DESCRIPTION
## Summary
- add optional date range, client, and truck filters to work order listings
- support client and date filtering on invoice listings
- test filtering by client, truck, and date for orders and invoices

## Testing
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6249873b48329bfb69ff4a44ba46b